### PR TITLE
Add current git branch name, if it isn't master, automatically after etalon update text on put new etalons page

### DIFF
--- a/PutFiles.aspx.cs
+++ b/PutFiles.aspx.cs
@@ -122,9 +122,9 @@ public partial class PutFiles : CbstHelper
 
 			if (strTestName != null)
 			{
-                		if (GetGitBranchName() != "master")
+                		if (Branch.Text != "master")
       	       			{
-                    			TextAreaMessage.Text = strTestName + ", etalon update " + GetGitBranchName();
+                    			TextAreaMessage.Text = strTestName + ", etalon update " + Branch.Text;
         			}
                 		else
                 		{

--- a/PutFiles.aspx.cs
+++ b/PutFiles.aspx.cs
@@ -122,8 +122,15 @@ public partial class PutFiles : CbstHelper
 
 			if (strTestName != null)
 			{
-				TextAreaMessage.Text = strTestName + ", etalon update ";
-			}
+                		if (GetGitBranchName() != "master")
+      	       			{
+                    			TextAreaMessage.Text = strTestName + ", etalon update " + GetGitBranchName();
+        			}
+                		else
+                		{
+                    			TextAreaMessage.Text = strTestName + ", etalon update ";
+                		}
+            		}
 			TextAreaMessage.Focus();
 		}
 	}


### PR DESCRIPTION
Could be a useful feature